### PR TITLE
Ensure binary is statically linked rather than linked against musl libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ submodules:
 $(dapperdox_bin):
 	mkdir -p $(dapperdox_build_dir)
 	cp -r dapperdox/* "$(dapperdox_build_dir)/"
-	cd "$(dapperdox_build_dir)"; make
+	cd "$(dapperdox_build_dir)"; CGO_ENABLED=0 make
 	cp "$(dapperdox_build_dir)/dapperdox" ./dapperdox/
 
 .PHONY: build


### PR DESCRIPTION
This change disables the cgo tool—which is enabled by default—in order to ensure that the binary is statically linked otherwise the resulting binary will be linked against the musl libc implementation from the Alpine build container, meaning it will fail to run in end-to-end environments which do not contain this shared library.