### PR TITLE
Add Docker support to Dapperdox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.gitignore
+version
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM golang:1.15-alpine as builder
+
+ENV GOPRIVATE="github.com/companieshouse"
+
+RUN apk add --no-cache git openssh-client build-base
+
+RUN git config --global url."git@github.com:".insteadOf https://github.com/
+
+WORKDIR /build
+
+ARG SSH_PRIVATE_KEY
+ARG SSH_PRIVATE_KEY_PASSPHRASE
+
+RUN mkdir -m 0600 ~/.ssh \
+    && ssh-keyscan github.com >> ~/.ssh/known_hosts \
+    && echo "${SSH_PRIVATE_KEY}" > ~/.ssh/id_rsa \
+    && chmod 600 ~/.ssh/id_rsa \
+    && ssh-keygen -p -f ~/.ssh/id_rsa -P "${SSH_PRIVATE_KEY_PASSPHRASE}" -N ""
+
+COPY . ./
+
+RUN make
+
+FROM alpine:3.12
+
+WORKDIR /app
+
+COPY --from=builder /build ./
+
+CMD ["./docker_start.sh"]

--- a/Tiltfile.dev
+++ b/Tiltfile.dev
@@ -1,0 +1,14 @@
+custom_build(
+  ref = '169942020521.dkr.ecr.eu-west-1.amazonaws.com/local/dapperdox.developer.ch.gov.uk:latest',
+  command = 'DOCKER_BUILDKIT=0 docker build --build-arg SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)" --build-arg SSH_PRIVATE_KEY_PASSPHRASE --tag $EXPECTED_REF .',
+  live_update = [
+    sync('./assets', '/app/assets'),
+    sync('./dapperdox', '/app/dapperdox'),
+    sync('./specs', '/app/specs'),
+    sync('./themes', '/app/themes'),
+    restart_container(),
+  ],
+  deps = [
+    './'
+  ]
+)

--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env ash
+#
+# Docker start script for developer.gov.uk
+
+source ./spec_args.sh
+
+echo "Runing Dapperdox with specs arguments=[${SPEC_ARGS}]"
+DAPPERDOX=${PWD}/dapperdox
+
+${DAPPERDOX}/dapperdox ${SPEC_ARGS} \
+    -bind-addr=0.0.0.0:${PORT} \
+    -site-url=${DAPPERDOX_DEVELOPER_URL} \
+    -default-assets-dir=${DAPPERDOX}/assets \
+    -proxy-path=/developer=http://localhost:${CHS_DEVELOPER_MOJO_PORT} \
+    -force-specification-list=true \
+    -assets-dir=${PWD}/assets \
+    -theme-dir=${PWD}/themes/ \
+    -theme=dapperdox-theme-gov-uk  \
+# additional/future options below as they mess up the multi line command if they are in between non commented lines
+#    -log-level=info \
+#    -spec-rewrite-url=api.companieshouse.gov.uk=${API_URL} \
+#    -author-show-assets=true \

--- a/spec_args.sh
+++ b/spec_args.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+# Only public spec files should be added to this block
+SPEC_ARGS="-spec-dir=${PWD}/specs"
+SPEC_ARGS="${SPEC_ARGS} -spec-rewrite-url=http://localhost:3123/swagger-2.0=http://127.0.0.1:${PORT}/api.ch.gov.uk-specifications/swagger-2.0"
+SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/streaming.json" # public streaming api specs
+
+
+# Pending public spec files for API Filing initial release
+if [[ "${INCLUDE_API_FILING_PUBLIC_SPECS}" -eq "1" ]]; then
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/swagger.json"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=document.api.ch.gov.uk-specifications/swagger-2.0/spec/swagger.json"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=account.ch.gov.uk-specifications/swagger-2.0/identity-public.json"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/filings-public.json"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/testDataGenerator.json"
+fi
+
+# Pending public spec files should be added to this block
+# This should be used for specs that are going to be public but currently not ready to be made publicly available
+if [[ "${INCLUDE_PENDING_PUBLIC_SPECS}" -eq "1" ]]; then
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/payments.json" # pending public payment api specs
+fi
+
+
+# Only private/internal spec files should be added to this block
+if [[ "${INCLUDE_PRIVATE_SPECS}" -eq "1" ]]; then
+    echo "Including private specs"
+    SPEC_ARGS="${SPEC_ARGS} -spec-rewrite-url=http://localhost:3123/swagger-2.0-private=http://127.0.0.1:${PORT}/private.api.ch.gov.uk-specifications/swagger-2.0-private"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/filings.json" # private filing api specs
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=private.api.ch.gov.uk-specifications/swagger-2.0-private/spec/chs-kafka-api.json"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/orders.json"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=private.api.ch.gov.uk-specifications/swagger-2.0-private/spec/chd-order-api.json"
+    SPEC_ARGS="${SPEC_ARGS} -spec-filename=private.api.ch.gov.uk-specifications/swagger-2.0-private/spec/search.api.gov.uk.json"
+fi

--- a/start.sh
+++ b/start.sh
@@ -29,38 +29,7 @@ else
     export PATH
 fi
 
-# Only public spec files should be added to this block
-SPEC_ARGS="-spec-dir=${PWD}/specs"
-SPEC_ARGS="${SPEC_ARGS} -spec-rewrite-url=http://localhost:3123/swagger-2.0=http://127.0.0.1:${PORT}/api.ch.gov.uk-specifications/swagger-2.0"
-SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/streaming.json" # public streaming api specs
-
-
-# Pending public spec files for API Filing initial release
-if [[ "${INCLUDE_API_FILING_PUBLIC_SPECS}" -eq "1" ]]; then
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/swagger.json"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=document.api.ch.gov.uk-specifications/swagger-2.0/spec/swagger.json"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=account.ch.gov.uk-specifications/swagger-2.0/identity-public.json"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/filings-public.json"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/testDataGenerator.json"
-fi
-
-# Pending public spec files should be added to this block
-# This should be used for specs that are going to be public but currently not ready to be made publicly available
-if [[ "${INCLUDE_PENDING_PUBLIC_SPECS}" -eq "1" ]]; then
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/payments.json" # pending public payment api specs
-fi
-
-
-# Only private/internal spec files should be added to this block
-if [[ "${INCLUDE_PRIVATE_SPECS}" -eq "1" ]]; then
-    echo "Including private specs"
-    SPEC_ARGS="${SPEC_ARGS} -spec-rewrite-url=http://localhost:3123/swagger-2.0-private=http://127.0.0.1:${PORT}/private.api.ch.gov.uk-specifications/swagger-2.0-private"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/filings.json" # private filing api specs
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=private.api.ch.gov.uk-specifications/swagger-2.0-private/spec/chs-kafka-api.json"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=api.ch.gov.uk-specifications/swagger-2.0/spec/orders.json"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=private.api.ch.gov.uk-specifications/swagger-2.0-private/spec/chd-order-api.json"
-    SPEC_ARGS="${SPEC_ARGS} -spec-filename=private.api.ch.gov.uk-specifications/swagger-2.0-private/spec/search.api.gov.uk.json"
-fi
+source ./spec_args.sh
 
 echo "Runing Dapperdox with specs arguments=[${SPEC_ARGS}]"
 DAPPERDOX=${APP_DIR}/dapperdox


### PR DESCRIPTION
- Refactors the `start.sh` script to extract the setting of `SPEC_ARGS` into separate `spec_args.sh` script - uses `sh` as default shell due to differences between Mesos and Docker default shells
- Adds a `docker_start.sh` shell script
- Adds a Dockerfile
- Adds a .dockerignore
- Adds a Tiltfile.dev