### PR TITLE
description for Insolvency Summary as dapperdox asset

### DIFF
--- a/assets/sections/manipulate-company-data-api-filing/templates/reference/insolvency.md
+++ b/assets/sections/manipulate-company-data-api-filing/templates/reference/insolvency.md
@@ -1,0 +1,6 @@
+Overlay: true
+
+[[description]]
+ If you are filing an appointment of an Insolvency Practitioner, you can also file a change of registered office address via the Registered Office Address API with the same insolvency scope.
+ 
+ When you upload pdf documents, e.g. resolution document, a virus scan will be performed which will prevent you from closing the transaction immediately. It is recommended that you allow for a delay or repeated attempts to successfully close the transaction.


### PR DESCRIPTION
Second try (Overcomes unresolvable merge conflict in sub-module)

Switched to using the CHS Dev Env to work on this repo in development mode to incorporate the required changes for AC1 on the ticket whereby the Insolvency Summary page now has a custom description (dapperdox asset). Successfully tested the display of this modified page using the Tilt / Docker process.

Note, I think this is non-ideal because now the assets and spec for [api.ch.gov.uk](http://api.ch.gov.uk/) are separated. (And not possible to display the complete view for [api.ch.gov.uk](http://api.ch.gov.uk/) by simply running dapperdox on its own repo). However, it is not possible to specify multiple assets-dir for dapperdox (I tested it in various ways) and also this is how CH have set things up for other parts of the API specs. (The only other option I could see was to use sym links in the Docker container.)