### PR TITLE
ECCT-198 use merged api.ch.gov.uk-spec

### DIFF
--- a/docker_start.sh
+++ b/docker_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env ash
 #
 # Docker start script for developer.gov.uk
 


### PR DESCRIPTION
Just needed to properly reference the master branch of api.ch.gov.uk-specification that has been merged with the corresponding feature branch