### PR TITLE
Enable default cloudwatch alarms

### DIFF
--- a/terraform/groups/ecs-service/.gitignore
+++ b/terraform/groups/ecs-service/.gitignore
@@ -1,0 +1,1 @@
+.terraform*

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.216"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.218"
 
   # Environmental configuration
   environment             = var.environment
@@ -57,6 +57,9 @@ module "ecs-service" {
   use_capacity_provider              = var.use_capacity_provider
   use_fargate                        = var.use_fargate
   fargate_subnets                    = local.application_subnet_ids
+
+  # Cloudwatch
+  cloudwatch_alarms_enabled = var.cloudwatch_alarms_enabled
 
   # Service environment variable and secret configs
   task_environment            = local.task_environment

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -86,6 +86,15 @@ variable "service_scaleup_schedule" {
   default     = ""
 }
 
+# ----------------------------------------------------------------------
+# Cloudwatch alerts
+# ----------------------------------------------------------------------
+variable "cloudwatch_alarms_enabled" {
+  description = "Whether to create a standard set of cloudwatch alarms for the service.  Requires an SNS topic to have already been created for the stack."
+  type        = bool
+  default     = true
+}
+
 # ------------------------------------------------------------------------------
 # Service environment variable configs
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Update the ecs-service module to 1.0.218 and enable the use of CloudWatch alarms for all environments.

Resolves:
https://companieshouse.atlassian.net/browse/CC-804