### PR TITLE
Add missing config items to cidev 

### DIFF
--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,4 +4,6 @@ aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
 log_level = "info"
+include_api_filing_public_specs = "1"
+include_pending_public_specs = "1"
 include_private_specs = "1"

--- a/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
+++ b/terraform/groups/ecs-service/profiles/development-eu-west-2/cidev/vars
@@ -4,3 +4,4 @@ aws_profile = "development-eu-west-2"
 # service configs
 use_set_environment_files = true
 log_level = "info"
+include_private_specs = "1"


### PR DESCRIPTION
Dapperdox in cidev currently does not display private specs and between the config in `dapperdox-developer-ecs-service`

The following config items have been added
```
include_api_filing_public_specs = "1"
include_pending_public_specs = "1"
include_private_specs = "1"
```