### PR TITLE
Bump ecs-service module version to tighten security group rules

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.221"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.258"
 
   # Environmental configuration
   environment             = var.environment


### PR DESCRIPTION
Use later version of ecs-service module in order to address issue with the service security group rules being open to 0.0.0.0/0. This has been flagged by SecurityHub control EC2.18.

Partially resolves:
https://companieshouse.atlassian.net/browse/DVOP-2859
